### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,6 +9,8 @@ on:
             - master
 
 name: Linux build
+permissions:
+    contents: read
 jobs:
     py-check:
         runs-on: ${{ matrix.config.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/lalgonzales/gishndev/security/code-scanning/6](https://github.com/lalgonzales/gishndev/security/code-scanning/6)

To fix the issue, add a `permissions` block to the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow primarily involves reading repository contents and does not perform any write operations, the permissions can be set to `contents: read`. This ensures the workflow adheres to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional dependencies or changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
