### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: pypi
+permissions:
+    contents: read
 
 on:
     release:


### PR DESCRIPTION
Potential fix for [https://github.com/lalgonzales/gishndev/security/code-scanning/5](https://github.com/lalgonzales/gishndev/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the least privileges required for the workflow to function correctly. Since the workflow does not perform any repository modifications, we will set `contents: read` permissions at the root level of the workflow. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, minimizing potential security risks.

The `permissions` block will be added directly under the `name` key in the workflow file, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
