### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/installation.yml
+++ b/.github/workflows/installation.yml
@@ -10,6 +10,8 @@ on:
 
 
 name: Linux installation
+permissions:
+    contents: read
 jobs:
     test-ubuntu:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lalgonzales/gishndev/security/code-scanning/4](https://github.com/lalgonzales/gishndev/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves reading repository contents (e.g., checking out code and setting up Python), the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `test-ubuntu` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
