### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,6 +9,8 @@ on:
             - master
 
 name: macOS build
+permissions:
+  contents: read
 jobs:
     test-macOS:
         runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/lalgonzales/gishndev/security/code-scanning/3](https://github.com/lalgonzales/gishndev/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow involves checking out code and installing dependencies, it only needs `contents: read` permission. This ensures that the workflow adheres to the principle of least privilege.

The `permissions` block will be added after the `name` key (line 11) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
