### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,4 +1,6 @@
 name: docs-build
+permissions:
+    contents: read
 on:
     pull_request:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/lalgonzales/gishndev/security/code-scanning/2](https://github.com/lalgonzales/gishndev/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow primarily involves reading repository contents and does not perform any write operations, we will set `contents: read`. This ensures that the workflow has only the permissions it needs to function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
