### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
 name: docs
+permissions:
+    contents: write
 on:
     push:
         branches:


### PR DESCRIPTION
Potential fix for [https://github.com/lalgonzales/gishndev/security/code-scanning/1](https://github.com/lalgonzales/gishndev/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily reads repository contents and deploys documentation using `mkdocs gh-deploy`, which requires `contents: write`. Therefore, we will set `contents: write` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
